### PR TITLE
Change request payload type to JSON

### DIFF
--- a/lib/ebanx/command/request.rb
+++ b/lib/ebanx/command/request.rb
@@ -16,6 +16,10 @@ module Ebanx
         validate_presence :email
         validate_presence :payment_type_code
       end
+
+      def params
+        @params.to_json
+      end
     end
   end
 end


### PR DESCRIPTION
Request action in Pay expects the request body to be JSON encoded. This update is needed in order for the RequestObject to be correctly populated.